### PR TITLE
mon: enable msgr2

### DIFF
--- a/cmd/init_mon.go
+++ b/cmd/init_mon.go
@@ -40,7 +40,7 @@ const (
 [global]
 fsid = %s
 mon initial members = %s
-mon host = 127.0.0.1
+mon host = v2:127.0.0.1:3300/0
 osd crush chooseleaf type = 0
 osd journal size = 100
 public network = 0.0.0.0/0
@@ -66,7 +66,7 @@ rgw frontends = %s port=0.0.0.0:%s
 	monIP                 = "127.0.0.1"
 	monListenIPPort       = monIP + ":" + monPort
 	rgwEngine             = "civetweb"
-	monPort               = "6789"
+	monPort               = "3300"
 )
 
 var (

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -47,7 +47,7 @@ func TestGenerateCephConf(t *testing.T) {
 [global]
 fsid = 7ff73783-cec6-4ace-b655-a6bc4f2532a8
 mon initial members = toto
-mon host = 127.0.0.1
+mon host = v2:127.0.0.1:3300/0
 osd crush chooseleaf type = 0
 osd journal size = 100
 public network = 0.0.0.0/0


### PR DESCRIPTION
We now use msgr2 which binds on 3300 for the monitors.

Closes: https://github.com/ceph/cn-core/issues/8
Signed-off-by: Sébastien Han <seb@redhat.com>