### PR TITLE
adds ceph-volume support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,6 +25,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,7 +38,8 @@ var (
 )
 
 const (
-	cnMemMin uint64 = 512 // minimum amount of memory in MB to run cn-core
+	cnMemMin         uint64 = 512         // minimum amount of memory in MB to run cn-core
+	bluestoreSizeMin uint64 = 10737418240 // minimum amount of space for BlueStore in bytes
 )
 
 // cliInitCluster is the Cobra CLI call
@@ -65,6 +67,14 @@ func initCluster(cmd *cobra.Command, args []string) {
 	err := validateAvaibleMemory(cnMemMin, memLimit)
 	if err != nil {
 		log.Fatal(err)
+	}
+	// validate available bluestore block size, if the user has provided a dedicated directory
+	osdPathEnv := os.Getenv("OSD_PATH")
+	if len(osdPathEnv) > 0 {
+		err := validateAvailableBluestoreSize(bluestoreSizeMin, osdPathEnv)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	switch daemon {

--- a/cmd/init_mon.go
+++ b/cmd/init_mon.go
@@ -40,7 +40,7 @@ const (
 [global]
 fsid = %s
 mon initial members = %s
-mon host = v2:127.0.0.1:3300/0
+mon host = [v2:127.0.0.1:3300,v1:127.0.0.1:6789]
 osd crush chooseleaf type = 0
 osd journal size = 100
 public network = 0.0.0.0/0

--- a/cmd/init_mon.go
+++ b/cmd/init_mon.go
@@ -52,6 +52,7 @@ osd objectstore = bluestore
 osd memory target = %d
 osd memory base = %d
 osd memory cache min = %d
+bluestore_block_size = %d
 
 [client.rgw.%s]
 rgw dns name = %s

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -46,6 +46,7 @@ func TestGenerateCephConf(t *testing.T) {
 	osdMemoryTarget := 1
 	osdMemoryBase := 2
 	osdMemoryCacheMin := 3
+	bluestoreSizeMin := 4
 	expectedCephConf := `
 [global]
 fsid = 7ff73783-cec6-4ace-b655-a6bc4f2532a8
@@ -62,6 +63,7 @@ osd objectstore = bluestore
 osd memory target = 1
 osd memory base = 2
 osd memory cache min = 3
+bluestore_block_size = 4
 
 [client.rgw.toto]
 rgw dns name = toto
@@ -73,7 +75,7 @@ rgw usage max user shards = 1
 log file = /var/log/ceph/client.rgw.toto.log
 rgw frontends = civetweb port=0.0.0.0:8000
 `
-	assert.Equal(t, expectedCephConf, fmt.Sprintf(cephConfTemplate, fsid, hostname, osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin, hostname, hostname, hostname, rgwEngine, rgwPort), "Ceph configuration file generation error!")
+	assert.Equal(t, expectedCephConf, fmt.Sprintf(cephConfTemplate, fsid, hostname, osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin, bluestoreSizeMin, hostname, hostname, hostname, rgwEngine, rgwPort), "Ceph configuration file generation error!")
 }
 
 func TestValidateAvaibleMemory(t *testing.T) {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -51,7 +51,7 @@ func TestGenerateCephConf(t *testing.T) {
 [global]
 fsid = 7ff73783-cec6-4ace-b655-a6bc4f2532a8
 mon initial members = toto
-mon host = v2:127.0.0.1:3300/0
+mon host = [v2:127.0.0.1:3300,v1:127.0.0.1:6789]
 osd crush chooseleaf type = 0
 osd journal size = 100
 public network = 0.0.0.0/0


### PR DESCRIPTION
This commit
-adds default value of 10GB to bluestore_block_size in the config file
-adds a check for osd device, upon block device it reads bluestoreblocksize environment variable if available and sets appropriate block size in the config file and uses ceph-volume for deployment.
Fixes: #1 