### PR TITLE
daemon startup CLI: fix flags

### DIFF
--- a/cmd/init_mgr.go
+++ b/cmd/init_mgr.go
@@ -99,7 +99,7 @@ func generateMgrKeyring(hostname, mgrKeyringPath string) {
 func mgrStart(hostname string) {
 	log.Println("init mgr: running manager")
 
-	cmd := exec.Command("ceph-mgr", "--setuser", "ceph", "--setgroup", "-i", hostname)
+	cmd := exec.Command("ceph-mgr", "--setuser", "ceph", "--setgroup", "ceph", "-i", hostname)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/init_osd.go
+++ b/cmd/init_osd.go
@@ -157,12 +157,6 @@ func bootstrapOsd() {
 		}
 	}
 
-	// chown osd data path
-	err = chownR(osdDataPath, cephUID, cephGID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// start ceph osd!
 	osdStart()
 }
@@ -197,7 +191,7 @@ func generateOsdKeyring(monKeyringPath, osdKeyringPath string) {
 func osdMkfs(monInitialKeyringPath string) {
 	log.Println("init osd: populating osd store")
 
-	cmd := exec.Command("ceph-osd", "--conf", cephConfFilePath, "--mkfs", "-i", "0", "--osd-data", osdDataPath)
+	cmd := exec.Command("ceph-osd", "--setuser", "ceph", "--setgroup", "ceph", "--conf", cephConfFilePath, "--mkfs", "-i", "0", "--osd-data", osdDataPath)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -210,7 +204,7 @@ func osdMkfs(monInitialKeyringPath string) {
 func osdStart() {
 	log.Println("init osd: running osd")
 
-	cmd := exec.Command("ceph-osd", "--setuser", "ceph", "--setgroup", "-i", "0")
+	cmd := exec.Command("ceph-osd", "--setuser", "ceph", "--setgroup", "ceph", "-i", "0")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Some daemons were missing the --setgroup flag and some were incorrect.
Also since --mkfs has the right flag the correct permissions for the
'ceph' user will be applied so there is no need to chown the osd data
dir anymore.

Closes: https://github.com/ceph/cn-core/issues/13
Signed-off-by: Sébastien Han <seb@redhat.com>