### PR TITLE
config: shrink ceph.conf

### DIFF
--- a/cmd/init_mon.go
+++ b/cmd/init_mon.go
@@ -39,30 +39,11 @@ const (
 	cephConfTemplate = `
 [global]
 fsid = %s
-mon initial members = %s
 mon host = [v2:127.0.0.1:3300,v1:127.0.0.1:6789]
-osd crush chooseleaf type = 0
-osd journal size = 100
 public network = 0.0.0.0/0
 cluster network = 0.0.0.0/0
 log file = /dev/null
-osd pool default size = 1
-osd data = /var/lib/ceph/osd/ceph-0
-osd objectstore = bluestore
-osd memory target = %d
-osd memory base = %d
-osd memory cache min = %d
-bluestore_block_size = %d
 
-[client.rgw.%s]
-rgw dns name = %s
-rgw enable usage log = true
-rgw usage log tick interval = 1
-rgw usage log flush threshold = 1
-rgw usage max shards = 32
-rgw usage max user shards = 1
-log file = /var/log/ceph/client.rgw.%s.log
-rgw frontends = %s endpoint=0.0.0.0:%s
 `
 
 	monMapPath            = "/etc/ceph/monmap"
@@ -71,6 +52,7 @@ rgw frontends = %s endpoint=0.0.0.0:%s
 	monListenIPPort       = monIP + ":" + monPort
 	rgwEngine             = "beast"
 	monPort               = "3300"
+	osdPoolDefaultSize    = "1"
 )
 
 var (
@@ -192,7 +174,8 @@ func monMkfs(hostname, monInitialKeyringPath, monDataPath, monMapPath string) {
 func monStart(hostname, monDataPath string) {
 	log.Println("init mon: running monitor")
 
-	cmd := exec.Command("ceph-mon", "--setuser", "ceph", "--setgroup", "ceph", "-i", hostname, "--mon-data", monDataPath, "--public-addr", monListenIPPort)
+	cmd := exec.Command("ceph-mon", "--setuser", "ceph", "--setgroup", "ceph", "-i", hostname, "--mon-data", monDataPath, "--public-addr", monListenIPPort, "--mon-initial-members", hostname,
+		"--osd-pool-default-size", osdPoolDefaultSize)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -89,10 +89,7 @@ func generateUUID() string {
 
 func generateCephConf(hostname, rgwEngine, rgwPort string) (string, string) {
 	fsid := generateUUID()
-	memAvailable := getAvailableRAM()
-	osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin := tuneMemory(memAvailable)
-
-	return fmt.Sprintf(cephConfTemplate, fsid, hostname, osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin, bluestoreSizeMin, hostname, hostname, hostname, rgwEngine, rgwPort), fsid
+	return fmt.Sprintf(cephConfTemplate, fsid), fsid
 }
 
 func writeCephConf(hostname, cephConfFilePath string) string {
@@ -344,25 +341,25 @@ func tuneMemory(memAvailable uint64) (osdMemoryTarget uint64, osdMemoryBase uint
 	_128mB := mbTob(128)
 	_4096mB := mbTob(4096)
 
-	log.Printf("init mon: found %dMB of RAM available.\n", bToMb(memAvailable))
+	log.Printf("init osd: found %dMB of RAM available.\n", bToMb(memAvailable))
 
 	if memAvailable > _4096mB {
-		log.Println("init mon: more than 4GB of RAM is available. Caping OSD memory usage to 4GB.")
+		log.Println("init osd: more than 4GB of RAM is available. Caping OSD memory usage to 4GB.")
 		memAvailable = _4096mB
 	}
 
 	osdMemoryTarget = memAvailable - _50mB
 	if osdMemoryTarget < _128mB {
-		log.Fatalf("init mon: something strange is going on, I should have enough memory but osd_memory_target is too small: %dMB, cannot tune.\n", bToMb(osdMemoryTarget))
+		log.Fatalf("init osd: something strange is going on, I should have enough memory but osd_memory_target is too small: %dMB, cannot tune.\n", bToMb(osdMemoryTarget))
 	}
 
 	osdMemoryBase = memAvailable / 2
 	if osdMemoryBase < _128mB {
-		log.Fatalf("init mon: something strange is going on, I should have enough memory but  osd_memory_base is too small: %dMB, cannot tune.\n", bToMb(osdMemoryBase))
+		log.Fatalf("init osd: something strange is going on, I should have enough memory but  osd_memory_base is too small: %dMB, cannot tune.\n", bToMb(osdMemoryBase))
 	}
 
 	osdMemoryCacheMin = ((osdMemoryTarget-osdMemoryBase)/2 + osdMemoryBase)
-	log.Printf("init mon: tuning osd memory consumption with osd_memory_target: %dMB, osd_memory_base: %dMB and osd_memory_cache_min: %dMB.\n", bToMb(osdMemoryTarget), bToMb(osdMemoryBase), bToMb(osdMemoryCacheMin))
+	log.Printf("init osd: tuning osd memory consumption with osd_memory_target: %dMB, osd_memory_base: %dMB and osd_memory_cache_min: %dMB.\n", bToMb(osdMemoryTarget), bToMb(osdMemoryBase), bToMb(osdMemoryCacheMin))
 
 	return osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -42,40 +42,16 @@ func TestGenerateUUID(t *testing.T) {
 
 func TestGenerateCephConf(t *testing.T) {
 	fsid := "7ff73783-cec6-4ace-b655-a6bc4f2532a8"
-	hostname := "toto"
-	osdMemoryTarget := 1
-	osdMemoryBase := 2
-	osdMemoryCacheMin := 3
-	bluestoreSizeMin := 4
 	expectedCephConf := `
 [global]
 fsid = 7ff73783-cec6-4ace-b655-a6bc4f2532a8
-mon initial members = toto
 mon host = [v2:127.0.0.1:3300,v1:127.0.0.1:6789]
-osd crush chooseleaf type = 0
-osd journal size = 100
 public network = 0.0.0.0/0
 cluster network = 0.0.0.0/0
 log file = /dev/null
-osd pool default size = 1
-osd data = /var/lib/ceph/osd/ceph-0
-osd objectstore = bluestore
-osd memory target = 1
-osd memory base = 2
-osd memory cache min = 3
-bluestore_block_size = 4
 
-[client.rgw.toto]
-rgw dns name = toto
-rgw enable usage log = true
-rgw usage log tick interval = 1
-rgw usage log flush threshold = 1
-rgw usage max shards = 32
-rgw usage max user shards = 1
-log file = /var/log/ceph/client.rgw.toto.log
-rgw frontends = beast endpoint=0.0.0.0:8000
 `
-	assert.Equal(t, expectedCephConf, fmt.Sprintf(cephConfTemplate, fsid, hostname, osdMemoryTarget, osdMemoryBase, osdMemoryCacheMin, bluestoreSizeMin, hostname, hostname, hostname, rgwEngine, rgwPort), "Ceph configuration file generation error!")
+	assert.Equal(t, expectedCephConf, fmt.Sprintf(cephConfTemplate, fsid), "Ceph configuration file generation error!")
 }
 
 func TestValidateAvaibleMemory(t *testing.T) {


### PR DESCRIPTION
This commit
- Removes mon-initial-members, osd and client rgw section from the config file, instead passes it through CLI.

Fixes:#17
Signed-off-by: Deepika Joshi <djoshi@redhat.com>