### PR TITLE
contrib & dockerfile: updates base image and adds latest tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # more information refer https://golang.org/doc/go1.4#canonicalimports
 #
 
-FROM ceph/daemon:latest-master
+FROM ceph/daemon:v4.0.0-stable-4.0-nautilus-centos-7-x86_64
 
 ADD cn-core /usr/local/bin/
 

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -178,7 +178,9 @@ sudo docker build -t cn-core .
 echo "Pushing cn-core container image to quay.io"
 sudo docker login -u="leseb" -p="A8LHJJ1Kph6JYpZNDs7fLOYtitLhSIlQwAIeV7RvgleJJwPf/EUk647GSKMN8yij9kJLgJn/5uxneknBI6Qqw/Cjh8XN+x3xUhbi9gMfWJQ=" quay.io
 sudo docker tag cn-core quay.io/ceph/cn-core:"${TAG}"
+sudo docker tag cn-core quay.io/ceph/cn-core:latest
 sudo docker push quay.io/ceph/cn-core:"${TAG}"
+sudo docker push quay.io/ceph/cn-core:latest
 
 rm cn-core || fatal "Cannot remove cn-core"
 ln -sf cn-*-"$LOCAL_ARCH" cn || fatal "Cannot link cn for $LOCAL_ARCH"


### PR DESCRIPTION
-updates the base image to nautilus stable image.
-adds latest tag to the image.

Signed-off-by: Deepika Joshi <djoshi@redhat.com>