### PR TITLE
mgr: always fetch admin keyring

### DIFF
--- a/cmd/init_mgr.go
+++ b/cmd/init_mgr.go
@@ -70,16 +70,17 @@ func mgrPreReq(mgrDataPath, monKeyringPath string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		out, args, err := fetchAdminKeyring(monKeyringPath)
-		if err != nil {
-			fmt.Printf("The command was: %s\n", args)
-			fmt.Printf("The error was: %s\n", out)
-			log.Fatal(err)
-		}
-		err = os.Chown(adminKeyringPath, cephUID, cephGID)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}
+
+	out, args, err := fetchAdminKeyring(monKeyringPath)
+	if err != nil {
+		fmt.Printf("The command was: %s\n", args)
+		fmt.Printf("The error was: %s\n", out)
+		log.Fatal(err)
+	}
+	err = os.Chown(adminKeyringPath, cephUID, cephGID)
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This commit
- modifies mgrPreReq function to always fetch the admin keyring.

Signed-off-by: Deepika Joshi <djoshi@redhat.com>