### PR TITLE
mon: add RGW_FRONTEND_PORT variable

### DIFF
--- a/cmd/init_mon.go
+++ b/cmd/init_mon.go
@@ -66,6 +66,11 @@ func bootstrapMon() {
 	}
 
 	// Read ENV and search for a value for rgwPort
+	if rgwPortEnv := os.Getenv("RGW_FRONTEND_PORT"); rgwPortEnv != "" {
+		rgwPort = rgwPortEnv
+	}
+
+	// Keep this for backward compatiblity, the option is gone since https://github.com/ceph/ceph-container/pull/1356
 	rgwPortEnv := os.Getenv("RGW_CIVETWEB_PORT")
 	if len(rgwPortEnv) > 0 {
 		rgwPort = rgwPortEnv


### PR DESCRIPTION
This commit
- adds support for RGW_FRONTEND_PORT.

Since the PR ceph/ceph-container#1356, the RGW_CIVETWEB_PORT option has been dropped; we retain it for compatibility with the older versions.

Signed-off-by: Deepika Joshi <djoshi@redhat.com>